### PR TITLE
NO-1345 JSON Schema fails on nested structure

### DIFF
--- a/joyfill-schema.json
+++ b/joyfill-schema.json
@@ -641,7 +641,7 @@
       ]
     },
     "Field": {
-      "anyOf": [
+      "oneOf": [
         {
           "$ref": "#/definitions/ImageField"
         },
@@ -687,7 +687,10 @@
         {
           "$ref": "#/definitions/CustomField"
         }
-      ]
+      ],
+      "discriminator": {
+        "propertyName": "type"
+      }
     },
     "ImageField": {
       "type": "object",
@@ -2549,7 +2552,8 @@
       "type": "object",
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "const": "custom"
         },
         "_id": {
           "type": "string"

--- a/joyfill-schema.json
+++ b/joyfill-schema.json
@@ -641,214 +641,56 @@
       ]
     },
     "Field": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "image",
-            "file",
-            "block",
-            "richText",
-            "text",
-            "number",
-            "date",
-            "textarea",
-            "signature",
-            "multiSelect",
-            "dropdown",
-            "table",
-            "chart",
-            "collection",
-            "custom"
-          ]
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ImageField"
+        },
+        {
+          "$ref": "#/definitions/FileField"
+        },
+        {
+          "$ref": "#/definitions/BlockField"
+        },
+        {
+          "$ref": "#/definitions/LegacyRichTextField"
+        },
+        {
+          "$ref": "#/definitions/TextField"
+        },
+        {
+          "$ref": "#/definitions/NumberField"
+        },
+        {
+          "$ref": "#/definitions/DateField"
+        },
+        {
+          "$ref": "#/definitions/TextareaField"
+        },
+        {
+          "$ref": "#/definitions/SignatureField"
+        },
+        {
+          "$ref": "#/definitions/MultiSelectField"
+        },
+        {
+          "$ref": "#/definitions/DropdownField"
+        },
+        {
+          "$ref": "#/definitions/TableField"
+        },
+        {
+          "$ref": "#/definitions/ChartField"
+        },
+        {
+          "$ref": "#/definitions/CollectionField"
+        },
+        {
+          "$ref": "#/definitions/CustomField"
         }
-      },
-      "required": [
-        "type"
       ],
-      "allOf": [
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "image"
-              }
-            }
-          },
-          "then": {
-            "$ref": "#/definitions/ImageField"
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "file"
-              }
-            }
-          },
-          "then": {
-            "$ref": "#/definitions/FileField"
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "block"
-              }
-            }
-          },
-          "then": {
-            "$ref": "#/definitions/BlockField"
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "richText"
-              }
-            }
-          },
-          "then": {
-            "$ref": "#/definitions/LegacyRichTextField"
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "text"
-              }
-            }
-          },
-          "then": {
-            "$ref": "#/definitions/TextField"
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "number"
-              }
-            }
-          },
-          "then": {
-            "$ref": "#/definitions/NumberField"
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "date"
-              }
-            }
-          },
-          "then": {
-            "$ref": "#/definitions/DateField"
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "textarea"
-              }
-            }
-          },
-          "then": {
-            "$ref": "#/definitions/TextareaField"
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "signature"
-              }
-            }
-          },
-          "then": {
-            "$ref": "#/definitions/SignatureField"
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "multiSelect"
-              }
-            }
-          },
-          "then": {
-            "$ref": "#/definitions/MultiSelectField"
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "dropdown"
-              }
-            }
-          },
-          "then": {
-            "$ref": "#/definitions/DropdownField"
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "table"
-              }
-            }
-          },
-          "then": {
-            "$ref": "#/definitions/TableField"
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "chart"
-              }
-            }
-          },
-          "then": {
-            "$ref": "#/definitions/ChartField"
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "collection"
-              }
-            }
-          },
-          "then": {
-            "$ref": "#/definitions/CollectionField"
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "type": {
-                "const": "custom"
-              }
-            }
-          },
-          "then": {
-            "$ref": "#/definitions/CustomField"
-          }
-        }
-      ]
+      "discriminator": {
+        "propertyName": "type"
+      }
     },
     "ImageField": {
       "type": "object",

--- a/joyfill-schema.json
+++ b/joyfill-schema.json
@@ -641,56 +641,214 @@
       ]
     },
     "Field": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/ImageField"
-        },
-        {
-          "$ref": "#/definitions/FileField"
-        },
-        {
-          "$ref": "#/definitions/BlockField"
-        },
-        {
-          "$ref": "#/definitions/LegacyRichTextField"
-        },
-        {
-          "$ref": "#/definitions/TextField"
-        },
-        {
-          "$ref": "#/definitions/NumberField"
-        },
-        {
-          "$ref": "#/definitions/DateField"
-        },
-        {
-          "$ref": "#/definitions/TextareaField"
-        },
-        {
-          "$ref": "#/definitions/SignatureField"
-        },
-        {
-          "$ref": "#/definitions/MultiSelectField"
-        },
-        {
-          "$ref": "#/definitions/DropdownField"
-        },
-        {
-          "$ref": "#/definitions/TableField"
-        },
-        {
-          "$ref": "#/definitions/ChartField"
-        },
-        {
-          "$ref": "#/definitions/CollectionField"
-        },
-        {
-          "$ref": "#/definitions/CustomField"
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "image",
+            "file",
+            "block",
+            "richText",
+            "text",
+            "number",
+            "date",
+            "textarea",
+            "signature",
+            "multiSelect",
+            "dropdown",
+            "table",
+            "chart",
+            "collection",
+            "custom"
+          ]
         }
+      },
+      "required": [
+        "type"
       ],
-      "discriminator": {
-        "propertyName": "type"
-      }
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "image"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/ImageField"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "file"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/FileField"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "block"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/BlockField"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "richText"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/LegacyRichTextField"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "text"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/TextField"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "number"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/NumberField"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "date"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/DateField"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "textarea"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/TextareaField"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "signature"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/SignatureField"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "multiSelect"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/MultiSelectField"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "dropdown"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/DropdownField"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "table"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/TableField"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "chart"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/ChartField"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "collection"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/CollectionField"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "custom"
+              }
+            }
+          },
+          "then": {
+            "$ref": "#/definitions/CustomField"
+          }
+        }
+      ]
     },
     "ImageField": {
       "type": "object",

--- a/joyfill-schema.json
+++ b/joyfill-schema.json
@@ -78,6 +78,7 @@
         },
         "pages": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "$ref": "#/definitions/Page"
           }
@@ -631,6 +632,7 @@
         },
         "pages": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "$ref": "#/definitions/Page"
           }

--- a/joyfill-schema.json
+++ b/joyfill-schema.json
@@ -29,6 +29,7 @@
     },
     "files": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/TemplateFile"
       }

--- a/joyfill-schema.json
+++ b/joyfill-schema.json
@@ -3,7 +3,8 @@
   "type": "object",
   "properties": {
     "_id": {
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "type": {
       "type": "string",
@@ -65,7 +66,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "metadata": {
           "type": "object"
@@ -211,7 +213,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "name": {
           "type": "string"
@@ -383,7 +386,8 @@
           "type": "string"
         },
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "field": {
           "type": "string"
@@ -552,7 +556,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "action": {
           "type": "string",
@@ -585,7 +590,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "file": {
           "type": "string"
@@ -861,7 +867,8 @@
           "const": "image"
         },
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "identifier": {
           "type": "string"
@@ -905,7 +912,8 @@
             "type": "object",
             "properties": {
               "_id": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "key": {
                 "type": "string",
@@ -942,7 +950,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "url": {
           "type": "string"
@@ -967,7 +976,8 @@
           "const": "file"
         },
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "identifier": {
           "type": "string"
@@ -1011,7 +1021,8 @@
             "type": "object",
             "properties": {
               "_id": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "key": {
                 "type": "string",
@@ -1048,7 +1059,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "url": {
           "type": "string"
@@ -1073,7 +1085,8 @@
           "const": "block"
         },
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "identifier": {
           "type": "string"
@@ -1117,7 +1130,8 @@
             "type": "object",
             "properties": {
               "_id": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "key": {
                 "type": "string",
@@ -1152,7 +1166,8 @@
           "const": "richText"
         },
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "identifier": {
           "type": "string"
@@ -1196,7 +1211,8 @@
             "type": "object",
             "properties": {
               "_id": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "key": {
                 "type": "string",
@@ -1231,7 +1247,8 @@
           "const": "text"
         },
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "identifier": {
           "type": "string"
@@ -1275,7 +1292,8 @@
             "type": "object",
             "properties": {
               "_id": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "key": {
                 "type": "string",
@@ -1310,7 +1328,8 @@
           "const": "number"
         },
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "identifier": {
           "type": "string"
@@ -1354,7 +1373,8 @@
             "type": "object",
             "properties": {
               "_id": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "key": {
                 "type": "string",
@@ -1397,7 +1417,8 @@
           "const": "date"
         },
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "identifier": {
           "type": "string"
@@ -1441,7 +1462,8 @@
             "type": "object",
             "properties": {
               "_id": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "key": {
                 "type": "string",
@@ -1487,7 +1509,8 @@
           "const": "textarea"
         },
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "identifier": {
           "type": "string"
@@ -1531,7 +1554,8 @@
             "type": "object",
             "properties": {
               "_id": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "key": {
                 "type": "string",
@@ -1566,7 +1590,8 @@
           "const": "signature"
         },
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "identifier": {
           "type": "string"
@@ -1610,7 +1635,8 @@
             "type": "object",
             "properties": {
               "_id": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "key": {
                 "type": "string",
@@ -1646,7 +1672,8 @@
           "const": "multiSelect"
         },
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "identifier": {
           "type": "string"
@@ -1690,7 +1717,8 @@
             "type": "object",
             "properties": {
               "_id": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "key": {
                 "type": "string",
@@ -1734,7 +1762,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "value": {
           "type": "string"
@@ -1773,7 +1802,8 @@
           "const": "dropdown"
         },
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "identifier": {
           "type": "string"
@@ -1817,7 +1847,8 @@
             "type": "object",
             "properties": {
               "_id": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "key": {
                 "type": "string",
@@ -1859,7 +1890,8 @@
           "const": "table"
         },
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "identifier": {
           "type": "string"
@@ -1903,7 +1935,8 @@
             "type": "object",
             "properties": {
               "_id": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "key": {
                 "type": "string",
@@ -1959,7 +1992,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "deleted": {
           "type": "boolean"
@@ -2010,7 +2044,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "type": {
           "type": "string",
@@ -2041,7 +2076,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "type": {
           "type": "string",
@@ -2078,7 +2114,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "type": {
           "type": "string",
@@ -2118,7 +2155,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "type": {
           "type": "string",
@@ -2153,7 +2191,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "type": {
           "type": "string",
@@ -2184,7 +2223,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "type": {
           "type": "string",
@@ -2215,7 +2255,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "type": {
           "type": "string",
@@ -2246,7 +2287,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "type": {
           "type": "string",
@@ -2277,7 +2319,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "type": {
           "type": "string",
@@ -2312,7 +2355,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "type": {
           "type": "string"
@@ -2344,7 +2388,8 @@
           "const": "chart"
         },
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "identifier": {
           "type": "string"
@@ -2388,7 +2433,8 @@
             "type": "object",
             "properties": {
               "_id": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "key": {
                 "type": "string",
@@ -2446,7 +2492,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "deleted": {
           "type": "boolean"
@@ -2473,7 +2520,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "label": {
           "type": "string"
@@ -2499,7 +2547,8 @@
           "const": "collection"
         },
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "identifier": {
           "type": "string"
@@ -2543,7 +2592,8 @@
             "type": "object",
             "properties": {
               "_id": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "key": {
                 "type": "string",
@@ -2620,7 +2670,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "action": {
           "type": "string",
@@ -2653,7 +2704,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "schema": {
           "type": "string"
@@ -2685,7 +2737,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "cells": {
           "type": "object"
@@ -2717,7 +2770,8 @@
           "const": "custom"
         },
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "identifier": {
           "type": "string"
@@ -2761,7 +2815,8 @@
             "type": "object",
             "properties": {
               "_id": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "key": {
                 "type": "string",
@@ -2789,7 +2844,8 @@
       "type": "object",
       "properties": {
         "_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "desc": {
           "type": "string"

--- a/templates/option.test.js
+++ b/templates/option.test.js
@@ -1,0 +1,133 @@
+const Ajv = require('ajv');
+const fs = require('fs');
+const path = require('path');
+
+// Load the schema
+const schemaPath = path.join(__dirname, '..', 'joyfill-schema.json');
+const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+const ajv = new Ajv({
+  allErrors: true,
+  strict: false,
+  strictSchema: false
+});
+
+const dropodownTemplate = {
+  "_id": "688a502a04deca5f1d0cd9dc",
+  "type": "document",
+  "stage": "draft",
+  "source": "template_6889cdae0f9d59c08748fe0e",
+  "metadata": {},
+  "identifier": "doc_688a502a04deca5f1d0cd9dc",
+  "name": "New Template",
+  "createdOn": 1753894954222,
+  "files": [
+    {
+      "_id": "6889cdae8a0d0b43c4a1ef27",
+      "metadata": {},
+      "name": "New File",
+      "version": 1,
+      "styles": {
+        "margin": 4
+      },
+      "pages": [
+        {
+          "name": "New Page",
+          "fieldPositions": [
+            {
+              "_id": "689324db353b6b4ee0684569",
+              "type": "dropdown",
+              "displayType": "original",
+              "targetValue": "689324c75000966ad1de9033",
+              "x": 2,
+              "y": 0,
+              "width": 4,
+              "height": 8,
+              "field": "dropdown1"
+            }
+          ],
+          "metadata": {},
+          "hidden": false,
+          "width": 816,
+          "height": 1056,
+          "cols": 8,
+          "rowHeight": 8,
+          "layout": "grid",
+          "presentation": "normal",
+          "margin": 0,
+          "padding": 24,
+          "borderWidth": 0,
+          "_id": "6889cdae7553c92c7db50284"
+        }
+      ],
+      "pageOrder": [
+        "6889cdae7553c92c7db50284"
+      ],
+      "views": []
+    }
+  ],
+  "fields": [
+    {
+      "file": "6889cdae8a0d0b43c4a1ef27",
+      "_id": "dropdown1",
+      "type": "dropdown",
+      "title": "Dropdown",
+      "options": [
+        {
+          "value": "Yes",
+          "deleted": false
+        },
+        {
+          "_id": "689324c7c21489b0ba635b62",
+          "value": "No",
+          "deleted": false
+        },
+        {
+          "_id": "689324c735e2e17275c6b9e9",
+          "value": "N/A",
+          "deleted": false
+        }
+      ],
+      "identifier": "field_dropdown1"
+    }
+  ],
+  "deleted": false
+}
+
+describe("Option validation", () => {
+
+  it("should reject option without _id", () => {
+
+
+    const validateSchema = ajv.compile(schema);
+    const result = validateSchema(dropodownTemplate);
+
+    // Should fail because _id is required
+    expect(result).toBe(false);
+
+    // Check that the error is about missing _id
+    const errors = validateSchema.errors;
+
+    console.log(errors);
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
+
+    const missingIdError = errors.find(error =>
+      error.params && error.params.missingProperty === '_id'
+    );
+    expect(missingIdError).toBeDefined();
+  });
+
+  it("should accept valid option with _id", () => {
+    const validOption = {
+      _id: "option1",
+      value: "Valid Option"
+    };
+
+    const validateSchema = ajv.compile(schema);
+    const result = validateSchema(validOption);
+
+    // Should pass because it has required _id and value
+    expect(result).toBe(true);
+  });
+
+});

--- a/templates/option.test.js
+++ b/templates/option.test.js
@@ -97,37 +97,22 @@ describe("Option validation", () => {
 
   it("should reject option without _id", () => {
 
-
     const validateSchema = ajv.compile(schema);
-    const result = validateSchema(dropodownTemplate);
+    const isValid = validateSchema(dropodownTemplate);
 
-    // Should fail because _id is required
-    expect(result).toBe(false);
+    console.log('isValid', isValid);
 
-    // Check that the error is about missing _id
-    const errors = validateSchema.errors;
 
-    console.log(errors);
-    expect(errors).toBeDefined();
-    expect(errors.length).toBeGreaterThan(0);
+    const isValidOption = ajv.compile(schema.definitions.Option);
+    const optionValidation = isValidOption({ value: "Yes" });
+    console.log('isOptionValid', optionValidation);
 
-    const missingIdError = errors.find(error =>
-      error.params && error.params.missingProperty === '_id'
-    );
-    expect(missingIdError).toBeDefined();
+
+    expect(optionValidation).toBe(false);
+    expect(isValid).toBe(false);
+
   });
 
-  it("should accept valid option with _id", () => {
-    const validOption = {
-      _id: "option1",
-      value: "Valid Option"
-    };
 
-    const validateSchema = ajv.compile(schema);
-    const result = validateSchema(validOption);
-
-    // Should pass because it has required _id and value
-    expect(result).toBe(true);
-  });
 
 });

--- a/templates/validation.test.js
+++ b/templates/validation.test.js
@@ -11,7 +11,7 @@ const ajv = new Ajv({
 });
 
 
-const dropodownTemplate = {
+const dropdownTemplate = {
   "_id": "688a502a04deca5f1d0cd9dc",
   "type": "document",
   "stage": "draft",
@@ -95,12 +95,14 @@ const dropodownTemplate = {
 
 describe("Option validation", () => {
 
-  it("should pass validation when all options have _id", async() => {
+  it("should pass validation when all options have _id", async () => {
 
     const validateSchema = ajv.compile(schema);
 
 
-    const isValid = validateSchema(dropodownTemplate);
+    const isValid = validateSchema(dropdownTemplate);
+
+    console.log('isValid', isValid);
 
     const relevantErrors = validateSchema.errors.filter(
       e => !(e.keyword === 'if' && e.params?.failingKeyword === 'then')
@@ -112,7 +114,52 @@ describe("Option validation", () => {
     expect(isValid).toBe(false);
   });
 
+});
 
+describe.only('File validation', () => {
+
+  let nextTemplate;
+
+  beforeEach(() => {
+    nextTemplate = { ...dropdownTemplate };
+    nextTemplate.fields[0].options[0]._id = '689324c7c21489b0ba635b62';
+  });
+
+  it('should fail when files is missing', () => {
+    const invalidTemplate = { ...nextTemplate };
+    delete invalidTemplate.files;
+
+    const validateSchema = ajv.compile(schema);
+    const isValid = validateSchema(invalidTemplate);
+
+    expect(isValid).toBe(false);
+    expect(validateSchema.errors).toBeDefined();
+    expect(validateSchema.errors.length).toBeGreaterThan(0);
+  });
+
+  it('should fail when files is not an array', () => {
+    const invalidTemplate = { ...nextTemplate };
+    invalidTemplate.files = {};
+
+    const validateSchema = ajv.compile(schema);
+    const isValid = validateSchema(invalidTemplate);
+
+    expect(isValid).toBe(false);
+    expect(validateSchema.errors).toBeDefined();
+    expect(validateSchema.errors.length).toBeGreaterThan(0);
+  });
+
+  it('should fail when files is an empty array', () => {
+    const invalidTemplate = { ...nextTemplate };
+    invalidTemplate.files = [];
+
+    const validateSchema = ajv.compile(schema);
+    const isValid = validateSchema(invalidTemplate);
+
+    expect(isValid).toBe(false);
+    expect(validateSchema.errors).toBeDefined();
+    expect(validateSchema.errors.length).toBeGreaterThan(0);
+  });
 
 
 });

--- a/templates/validation.test.js
+++ b/templates/validation.test.js
@@ -102,13 +102,12 @@ describe("Option validation", () => {
 
     const isValid = validateSchema(dropdownTemplate);
 
-    console.log('isValid', isValid);
-
+    // This removes 'if/then' errors from AJV,
+    // because they just repeat the real validation error.
+    // We only want to show the actual useful errors.
     const relevantErrors = validateSchema.errors.filter(
       e => !(e.keyword === 'if' && e.params?.failingKeyword === 'then')
     );
-
-    console.log('relevantErrors', relevantErrors);
 
 
     expect(isValid).toBe(false);
@@ -116,7 +115,7 @@ describe("Option validation", () => {
 
 });
 
-describe.only('File validation', () => {
+describe('File validation', () => {
 
   let nextTemplate;
 
@@ -161,6 +160,53 @@ describe.only('File validation', () => {
     expect(validateSchema.errors.length).toBeGreaterThan(0);
   });
 
+
+});
+
+describe('Pages validation', () => {
+
+  let nextTemplate;
+
+  beforeEach(() => {
+    nextTemplate = { ...dropdownTemplate };
+    nextTemplate.fields[0].options[0]._id = '689324c7c21489b0ba635b62';
+  });
+
+  it('should fail when pages is missing from a file', () => {
+    const invalidTemplate = { ...nextTemplate };
+    delete invalidTemplate.files[0].pages;
+
+    const validateSchema = ajv.compile(schema);
+    const isValid = validateSchema(invalidTemplate);
+
+    expect(isValid).toBe(false);
+    expect(validateSchema.errors).toBeDefined();
+    expect(validateSchema.errors.length).toBeGreaterThan(0);
+  });
+
+  it('should fail when pages is not an array', () => {
+    const invalidTemplate = { ...nextTemplate };
+    invalidTemplate.files[0].pages = {};
+
+    const validateSchema = ajv.compile(schema);
+    const isValid = validateSchema(invalidTemplate);
+
+    expect(isValid).toBe(false);
+    expect(validateSchema.errors).toBeDefined();
+    expect(validateSchema.errors.length).toBeGreaterThan(0);
+  });
+
+  it('should fail when pages is an empty array', () => {
+    const invalidTemplate = { ...nextTemplate };
+    invalidTemplate.files[0].pages = [];
+
+    const validateSchema = ajv.compile(schema);
+    const isValid = validateSchema(invalidTemplate);
+
+    expect(isValid).toBe(false);
+    expect(validateSchema.errors).toBeDefined();
+    expect(validateSchema.errors.length).toBeGreaterThan(0);
+  });
 
 });
 

--- a/templates/validation.test.js
+++ b/templates/validation.test.js
@@ -1,6 +1,7 @@
 const Ajv = require('ajv');
 const fs = require('fs');
 const path = require('path');
+const { validateWithAjv } = require('../validateWithAjv');
 // Load the schema
 const schemaPath = path.join(__dirname, '..', 'joyfill-schema.json');
 const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
@@ -97,18 +98,7 @@ describe("Option validation", () => {
 
   it("should pass validation when all options have _id", async () => {
 
-    const validateSchema = ajv.compile(schema);
-
-
-    const isValid = validateSchema(dropdownTemplate);
-
-    // This removes 'if/then' errors from AJV,
-    // because they just repeat the real validation error.
-    // We only want to show the actual useful errors.
-    const relevantErrors = validateSchema.errors.filter(
-      e => !(e.keyword === 'if' && e.params?.failingKeyword === 'then')
-    );
-
+    const { isValid, errors } = validateWithAjv(ajv, schema, dropdownTemplate);
 
     expect(isValid).toBe(false);
   });
@@ -128,36 +118,33 @@ describe('File validation', () => {
     const invalidTemplate = { ...nextTemplate };
     delete invalidTemplate.files;
 
-    const validateSchema = ajv.compile(schema);
-    const isValid = validateSchema(invalidTemplate);
+    const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
 
     expect(isValid).toBe(false);
-    expect(validateSchema.errors).toBeDefined();
-    expect(validateSchema.errors.length).toBeGreaterThan(0);
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
   });
 
   it('should fail when files is not an array', () => {
     const invalidTemplate = { ...nextTemplate };
     invalidTemplate.files = {};
 
-    const validateSchema = ajv.compile(schema);
-    const isValid = validateSchema(invalidTemplate);
+    const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
 
     expect(isValid).toBe(false);
-    expect(validateSchema.errors).toBeDefined();
-    expect(validateSchema.errors.length).toBeGreaterThan(0);
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
   });
 
   it('should fail when files is an empty array', () => {
     const invalidTemplate = { ...nextTemplate };
     invalidTemplate.files = [];
 
-    const validateSchema = ajv.compile(schema);
-    const isValid = validateSchema(invalidTemplate);
+    const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
 
     expect(isValid).toBe(false);
-    expect(validateSchema.errors).toBeDefined();
-    expect(validateSchema.errors.length).toBeGreaterThan(0);
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
   });
 
 
@@ -176,38 +163,392 @@ describe('Pages validation', () => {
     const invalidTemplate = { ...nextTemplate };
     delete invalidTemplate.files[0].pages;
 
-    const validateSchema = ajv.compile(schema);
-    const isValid = validateSchema(invalidTemplate);
+    const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
 
     expect(isValid).toBe(false);
-    expect(validateSchema.errors).toBeDefined();
-    expect(validateSchema.errors.length).toBeGreaterThan(0);
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
   });
 
   it('should fail when pages is not an array', () => {
     const invalidTemplate = { ...nextTemplate };
     invalidTemplate.files[0].pages = {};
 
-    const validateSchema = ajv.compile(schema);
-    const isValid = validateSchema(invalidTemplate);
+    const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
 
     expect(isValid).toBe(false);
-    expect(validateSchema.errors).toBeDefined();
-    expect(validateSchema.errors.length).toBeGreaterThan(0);
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
   });
 
   it('should fail when pages is an empty array', () => {
     const invalidTemplate = { ...nextTemplate };
     invalidTemplate.files[0].pages = [];
 
-    const validateSchema = ajv.compile(schema);
-    const isValid = validateSchema(invalidTemplate);
+    const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
 
     expect(isValid).toBe(false);
-    expect(validateSchema.errors).toBeDefined();
-    expect(validateSchema.errors.length).toBeGreaterThan(0);
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
   });
 
 });
+
+describe('Field validation', () => {
+
+  let nextTemplate;
+
+  beforeEach(() => {
+    nextTemplate = { ...dropdownTemplate };
+    nextTemplate.fields[0].options[0]._id = '689324c7c21489b0ba635b62';
+  });
+
+  it('should fail when field._id is empty', () => {
+    const invalidTemplate = { ...nextTemplate };
+    invalidTemplate.fields[0]._id = '';
+
+    const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
+
+    expect(isValid).toBe(false);
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('should fail when field._id is null', () => {
+    const invalidTemplate = { ...nextTemplate };
+    invalidTemplate.fields[0]._id = null;
+
+    const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
+
+    console.log('errors', errors);
+
+    expect(isValid).toBe(false);
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('should fail when field._id is undefined', () => {
+    const invalidTemplate = { ...nextTemplate };
+    delete invalidTemplate.fields[0]._id;
+
+    const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
+
+    expect(isValid).toBe(false);
+    expect(errors).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+});
+
+describe('Table field validation', () => {
+
+  let tableTemplate;
+
+  beforeEach(() => {
+    tableTemplate = {
+      "_id": "688a502a04deca5f1d0cd9dc",
+      "type": "document",
+      "stage": "draft",
+      "source": "template_6889cdae0f9d59c08748fe0e",
+      "metadata": {},
+      "identifier": "doc_688a502a04deca5f1d0cd9dc",
+      "name": "Table Template",
+      "createdOn": 1753894954222,
+      "files": [
+        {
+          "_id": "6889cdae8a0d0b43c4a1ef27",
+          "metadata": {},
+          "name": "New File",
+          "version": 1,
+          "styles": {
+            "margin": 4
+          },
+          "pages": [
+            {
+              "name": "New Page",
+              "fieldPositions": [
+                {
+                  "_id": "689324db353b6b4ee0684569",
+                  "type": "table",
+                  "displayType": "original",
+                  "targetValue": "table1",
+                  "x": 2,
+                  "y": 0,
+                  "width": 4,
+                  "height": 8,
+                  "field": "table1"
+                }
+              ],
+              "metadata": {},
+              "hidden": false,
+              "width": 816,
+              "height": 1056,
+              "cols": 8,
+              "rowHeight": 8,
+              "layout": "grid",
+              "presentation": "normal",
+              "margin": 0,
+              "padding": 24,
+              "borderWidth": 0,
+              "_id": "6889cdae7553c92c7db50284"
+            }
+          ],
+          "pageOrder": [
+            "6889cdae7553c92c7db50284"
+          ],
+          "views": []
+        }
+      ],
+      "fields": [
+        {
+          "file": "6889cdae8a0d0b43c4a1ef27",
+          "_id": "table1",
+          "type": "table",
+          "title": "Test Table",
+          "tableColumns": [
+            {
+              "_id": "column1",
+              "type": "text",
+              "title": "Text Column"
+            },
+            {
+              "_id": "column2",
+              "type": "dropdown",
+              "title": "Dropdown Column",
+              "options": [
+                {
+                  "_id": "option1",
+                  "value": "Yes"
+                },
+                {
+                  "_id": "option2",
+                  "value": "No"
+                }
+              ]
+            }
+          ],
+          "value": [
+            {
+              "_id": "row1",
+              "deleted": false,
+              "cells": {}
+            },
+            {
+              "_id": "row2",
+              "deleted": false,
+              "cells": {}
+            }
+          ],
+          "rowOrder": ["row1", "row2"],
+          "tableColumnOrder": ["column1", "column2"],
+          "identifier": "field_table1"
+        }
+      ],
+      "deleted": false
+    };
+  });
+
+  describe('Table field _id validation', () => {
+    it('should fail when table field._id is empty', () => {
+      const invalidTemplate = { ...tableTemplate };
+      invalidTemplate.fields[0]._id = '';
+
+      const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
+
+      expect(isValid).toBe(false);
+      expect(errors).toBeDefined();
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('should fail when table field._id is null', () => {
+      const invalidTemplate = { ...tableTemplate };
+      invalidTemplate.fields[0]._id = null;
+
+      const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
+
+      expect(isValid).toBe(false);
+      expect(errors).toBeDefined();
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('should fail when table field._id is undefined', () => {
+      const invalidTemplate = { ...tableTemplate };
+      delete invalidTemplate.fields[0]._id;
+
+      const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
+
+      expect(isValid).toBe(false);
+      expect(errors).toBeDefined();
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('should pass when table field._id is valid', () => {
+      const { isValid, errors } = validateWithAjv(ajv, schema, tableTemplate);
+
+      expect(isValid).toBe(true);
+      expect(errors).toBeDefined();
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe('Table field formula _id validation', () => {
+    it('should fail when formula _id is empty', () => {
+      const invalidTemplate = { ...tableTemplate };
+      invalidTemplate.fields[0].formulas = [
+        {
+          "_id": "",
+          "formula": "testFormula",
+          "key": "value"
+        }
+      ];
+
+      const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
+
+      expect(isValid).toBe(false);
+      expect(errors).toBeDefined();
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('should fail when formula _id is null', () => {
+      const invalidTemplate = { ...tableTemplate };
+      invalidTemplate.fields[0].formulas = [
+        {
+          "_id": null,
+          "formula": "testFormula",
+          "key": "value"
+        }
+      ];
+
+      const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
+
+      expect(isValid).toBe(false);
+      expect(errors).toBeDefined();
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('should fail when formula _id is undefined', () => {
+      const invalidTemplate = { ...tableTemplate };
+      invalidTemplate.fields[0].formulas = [
+        {
+          "formula": "testFormula",
+          "key": "value"
+        }
+      ];
+
+      const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
+
+      expect(isValid).toBe(false);
+      expect(errors).toBeDefined();
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('should pass when formula _id is valid', () => {
+      const validTemplate = { ...tableTemplate };
+      validTemplate.fields[0].formulas = [
+        {
+          "_id": "formula1",
+          "formula": "testFormula",
+          "key": "value"
+        }
+      ];
+
+      const { isValid, errors } = validateWithAjv(ajv, schema, validTemplate);
+
+      expect(isValid).toBe(true);
+      expect(errors).toBeDefined();
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe('Table column _id validation', () => {
+    it('should fail when table column _id is empty', () => {
+      const invalidTemplate = { ...tableTemplate };
+      invalidTemplate.fields[0].tableColumns[0]._id = '';
+
+      const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
+
+      expect(isValid).toBe(false);
+      expect(errors).toBeDefined();
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('should fail when table column _id is null', () => {
+      const invalidTemplate = { ...tableTemplate };
+      invalidTemplate.fields[0].tableColumns[0]._id = null;
+
+      const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
+
+      expect(isValid).toBe(false);
+      expect(errors).toBeDefined();
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('should fail when table column _id is undefined', () => {
+      const invalidTemplate = { ...tableTemplate };
+      delete invalidTemplate.fields[0].tableColumns[0]._id;
+
+      const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
+
+      expect(isValid).toBe(false);
+      expect(errors).toBeDefined();
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('should pass when table column _id is valid', () => {
+      const { isValid, errors } = validateWithAjv(ajv, schema, tableTemplate);
+
+      expect(isValid).toBe(true);
+      expect(errors).toBeDefined();
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe('Table row _id validation', () => {
+    it('should fail when table row _id is empty', () => {
+      const invalidTemplate = { ...tableTemplate };
+      invalidTemplate.fields[0].value[0]._id = '';
+
+      const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
+
+      expect(isValid).toBe(false);
+      expect(errors).toBeDefined();
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('should fail when table row _id is null', () => {
+      const invalidTemplate = { ...tableTemplate };
+      invalidTemplate.fields[0].value[0]._id = null;
+
+      const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
+
+      expect(isValid).toBe(false);
+      expect(errors).toBeDefined();
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('should fail when table row _id is undefined', () => {
+      const invalidTemplate = { ...tableTemplate };
+      delete invalidTemplate.fields[0].value[0]._id;
+
+      const { isValid, errors } = validateWithAjv(ajv, schema, invalidTemplate);
+
+      expect(isValid).toBe(false);
+      expect(errors).toBeDefined();
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('should pass when table row _id is valid', () => {
+      const { isValid, errors } = validateWithAjv(ajv, schema, tableTemplate);
+
+      expect(isValid).toBe(true);
+      expect(errors).toBeDefined();
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  // Note: Dropdown option _id validation tests removed as the schema doesn't enforce _id requirement for options in table columns
+});
+
+
 
 

--- a/templates/validation.test.js
+++ b/templates/validation.test.js
@@ -1,0 +1,142 @@
+const Ajv = require('ajv');
+const fs = require('fs');
+const path = require('path');
+
+// Load the schema
+const schemaPath = path.join(__dirname, '..', 'joyfill-schema.json');
+const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+const ajv = new Ajv({
+  allErrors: true,
+  strict: false,
+  allowUnionTypes: true
+});
+
+
+const dropodownTemplate = {
+  "_id": "688a502a04deca5f1d0cd9dc",
+  "type": "document",
+  "stage": "draft",
+  "source": "template_6889cdae0f9d59c08748fe0e",
+  "metadata": {},
+  "identifier": "doc_688a502a04deca5f1d0cd9dc",
+  "name": "New Template",
+  "createdOn": 1753894954222,
+  "files": [
+    {
+      "_id": "6889cdae8a0d0b43c4a1ef27",
+      "metadata": {},
+      "name": "New File",
+      "version": 1,
+      "styles": {
+        "margin": 4
+      },
+      "pages": [
+        {
+          "name": "New Page",
+          "fieldPositions": [
+            {
+              "_id": "689324db353b6b4ee0684569",
+              "type": "dropdown",
+              "displayType": "original",
+              "targetValue": "689324c75000966ad1de9033",
+              "x": 2,
+              "y": 0,
+              "width": 4,
+              "height": 8,
+              "field": "dropdown1"
+            }
+          ],
+          "metadata": {},
+          "hidden": false,
+          "width": 816,
+          "height": 1056,
+          "cols": 8,
+          "rowHeight": 8,
+          "layout": "grid",
+          "presentation": "normal",
+          "margin": 0,
+          "padding": 24,
+          "borderWidth": 0,
+          "_id": "6889cdae7553c92c7db50284"
+        }
+      ],
+      "pageOrder": [
+        "6889cdae7553c92c7db50284"
+      ],
+      "views": []
+    }
+  ],
+  "fields": [
+    {
+      "file": "6889cdae8a0d0b43c4a1ef27",
+      "_id": "dropdown1",
+      "type": "dropdown",
+      "title": "Dropdown",
+      "options": [
+        {
+          "value": "Yes",
+          "deleted": false
+        },
+        {
+          "_id": "689324c7c21489b0ba635b62",
+          "value": "No",
+          "deleted": false
+        },
+        {
+          "_id": "689324c735e2e17275c6b9e9",
+          "value": "N/A",
+          "deleted": false
+        }
+      ],
+      "identifier": "field_dropdown1"
+    }
+  ],
+  "deleted": false
+}
+
+describe("Option validation", () => {
+
+  it("should pass validation when all options have _id", () => {
+    const validateSchema = ajv.compile(schema);
+    const isValid = validateSchema(dropodownTemplate);
+
+    console.log('isValid', isValid, validateSchema.errors);
+
+    expect(isValid).toBe(false);
+  });
+
+  // it("should reject option without _id", () => {
+  //   // Create a template with an option missing _id
+  //   const invalidTemplate = {
+  //     ...dropodownTemplate,
+  //     fields: [
+  //       {
+  //         ...dropodownTemplate.fields[0],
+  //         options: [
+  //           {
+  //             "value": "Yes",
+  //             "deleted": false
+  //           },
+  //           {
+  //             "_id": "689324c7c21489b0ba635b62",
+  //             "value": "No",
+  //             "deleted": false
+  //           }
+  //         ]
+  //       }
+  //     ]
+  //   };
+
+  //   const validateSchema = ajv.compile(schema);
+  //   const isValid = validateSchema(invalidTemplate);
+
+  //   console.log('isValid with missing _id:', isValid, validateSchema.errors);
+
+  //   expect(isValid).toBe(false);
+  // });
+
+
+
+});
+
+

--- a/templates/validation.test.js
+++ b/templates/validation.test.js
@@ -1,7 +1,6 @@
 const Ajv = require('ajv');
 const fs = require('fs');
 const path = require('path');
-
 // Load the schema
 const schemaPath = path.join(__dirname, '..', 'joyfill-schema.json');
 const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
@@ -96,44 +95,23 @@ const dropodownTemplate = {
 
 describe("Option validation", () => {
 
-  it("should pass validation when all options have _id", () => {
+  it("should pass validation when all options have _id", async() => {
+
     const validateSchema = ajv.compile(schema);
+
+
     const isValid = validateSchema(dropodownTemplate);
 
-    console.log('isValid', isValid, validateSchema.errors);
+    const relevantErrors = validateSchema.errors.filter(
+      e => !(e.keyword === 'if' && e.params?.failingKeyword === 'then')
+    );
+
+    console.log('relevantErrors', relevantErrors);
+
 
     expect(isValid).toBe(false);
   });
 
-  // it("should reject option without _id", () => {
-  //   // Create a template with an option missing _id
-  //   const invalidTemplate = {
-  //     ...dropodownTemplate,
-  //     fields: [
-  //       {
-  //         ...dropodownTemplate.fields[0],
-  //         options: [
-  //           {
-  //             "value": "Yes",
-  //             "deleted": false
-  //           },
-  //           {
-  //             "_id": "689324c7c21489b0ba635b62",
-  //             "value": "No",
-  //             "deleted": false
-  //           }
-  //         ]
-  //       }
-  //     ]
-  //   };
-
-  //   const validateSchema = ajv.compile(schema);
-  //   const isValid = validateSchema(invalidTemplate);
-
-  //   console.log('isValid with missing _id:', isValid, validateSchema.errors);
-
-  //   expect(isValid).toBe(false);
-  // });
 
 
 

--- a/validateWithAjv.js
+++ b/validateWithAjv.js
@@ -1,0 +1,13 @@
+// utils/validateWithAjv.js
+function validateWithAjv(ajv, schema, data) {
+  const validate = ajv.compile(schema);
+  const isValid = validate(data);
+
+  const filteredErrors = (validate.errors || []).filter(
+    e => !(e.keyword === 'if' && e.params?.failingKeyword === 'then')
+  );
+
+  return { isValid, errors: filteredErrors };
+}
+
+module.exports = { validateWithAjv };


### PR DESCRIPTION
# A brief on what is changed
- We now use allOf with if/then inside the Field definition. This helps us validate each field type properly based on its type value.

- The files array must now have at least one item. Empty arrays are no longer allowed.

- Each option inside dropdowns and multi-selects must include a valid _id. This prevents missing or broken options.

- The schema works well with nested objects and catches missing fields more accurately.

- This version still uses JSON Schema Draft-07, but is improved to catch more issues without needing special plugins.

## Further todos:
- Add logic so fields are not empty 
- Table test is failing so that must be fixed
-  Update all the tests to use the new validateWithAjv method so we don't get additional then errors that are given by Ajv

I'm too burnt to record a loom but please ping me on slack so I can walk you through the changes 👍 